### PR TITLE
Fix player model paths to local players folder

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,12 +223,12 @@
 
         function createPlayers() {
             const loader = new THREE.GLTFLoader();
-            // FIX: Replaced simple filenames with the full, correct paths for the uploaded models.
+            // Player model files live in the local "players" directory
             const playerModels = [
-                'kmberry1989/partyboard/partyboard-cc66a2d4f557615d58cb0ae92cc547c0169e54eb/players/jonah.glb',
-                'kmberry1989/partyboard/partyboard-cc66a2d4f557615d58cb0ae92cc547c0169e54eb/players/kyle.glb',
-                'kmberry1989/partyboard/partyboard-cc66a2d4f557615d58cb0ae92cc547c0169e54eb/players/rochelle.glb',
-                'kmberry1989/partyboard/partyboard-cc66a2d4f557615d58cb0ae92cc547c0169e54eb/players/vickie.glb'
+                'players/jonah.glb',
+                'players/kyle.glb',
+                'players/rochelle.glb',
+                'players/vickie.glb'
             ];
             const startPosition = boardSpaces[0].position;
 


### PR DESCRIPTION
## Summary
- load player piece models from local `players` directory

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fde933c5883288f828a00bea20a1e